### PR TITLE
fix(Modules): reject update when route id differs from body id, closes #27

### DIFF
--- a/FastSharp.Modules/Configuration/CRUDEndpoints.cs
+++ b/FastSharp.Modules/Configuration/CRUDEndpoints.cs
@@ -50,7 +50,7 @@ public class CRUDEndpoints<TDbContext, TEntity, TKey> : ICrudEndpoints<TDbContex
         GetByIdEndpoint = new GetByIdEndpoint<TDbContext, TEntity, TKey>(PredicateFactory);
         GetListEndpoint = new GetListEndpoint<TDbContext, TEntity, TKey>(IdSelector);
         CreateEndpoint = new CreateEndpoint<TDbContext, TEntity, TKey>(CrudPrefix);
-        UpdateEndpoint = new UpdateEndpoint<TDbContext, TEntity, TKey>(PredicateFactory);
+        UpdateEndpoint = new UpdateEndpoint<TDbContext, TEntity, TKey>(PredicateFactory, IdSelector);
         DeleteEndpoint = new DeleteEndpoint<TDbContext, TEntity, TKey>(PredicateFactory);
     }
 
@@ -118,7 +118,7 @@ public class CRUDEndpoints<TDbContext, TEntity, TKey> : ICrudEndpoints<TDbContex
         CreateEndpoint = new CreateEndpoint<TDbContext, TEntity, TKey, TDto>(CrudPrefix);
         CRUDEndpoints<TDbContext, TEntity, TKey>.ConfigureEndpoint(CreateEndpoint, configure);
 
-        UpdateEndpoint = new UpdateEndpoint<TDbContext, TEntity, TKey, TDto>(PredicateFactory);
+        UpdateEndpoint = new UpdateEndpoint<TDbContext, TEntity, TKey, TDto>(PredicateFactory, IdSelector);
         CRUDEndpoints<TDbContext, TEntity, TKey>.ConfigureEndpoint(UpdateEndpoint, configure);
     }
 
@@ -135,7 +135,7 @@ public class CRUDEndpoints<TDbContext, TEntity, TKey> : ICrudEndpoints<TDbContex
         CreateEndpoint = new CreateEndpoint<TDbContext, TEntity, TKey, TRequest, TResponse>(CrudPrefix);
         CRUDEndpoints<TDbContext, TEntity, TKey>.ConfigureEndpoint(CreateEndpoint, configure);
 
-        UpdateEndpoint = new UpdateEndpoint<TDbContext, TEntity, TKey, TRequest>(PredicateFactory);
+        UpdateEndpoint = new UpdateEndpoint<TDbContext, TEntity, TKey, TRequest>(PredicateFactory, IdSelector);
         CRUDEndpoints<TDbContext, TEntity, TKey>.ConfigureEndpoint(UpdateEndpoint, configure);
     }
 
@@ -177,7 +177,7 @@ public class CRUDEndpoints<TDbContext, TEntity, TKey> : ICrudEndpoints<TDbContex
 
     public void Update<TDto>(Action<RouteHandlerBuilder>? configure = null) where TDto : class
     {
-        UpdateEndpoint = new UpdateEndpoint<TDbContext, TEntity, TKey, TDto>(PredicateFactory);
+        UpdateEndpoint = new UpdateEndpoint<TDbContext, TEntity, TKey, TDto>(PredicateFactory, IdSelector);
         CRUDEndpoints<TDbContext, TEntity, TKey>.ConfigureEndpoint(UpdateEndpoint, configure);
     }
 

--- a/FastSharp.Modules/Core/Endpoints/UpdateEndpoint.cs
+++ b/FastSharp.Modules/Core/Endpoints/UpdateEndpoint.cs
@@ -8,12 +8,17 @@ using System.Linq.Expressions;
 
 namespace FastSharp.Modules.Core.Endpoints;
 
-internal class UpdateEndpoint<TDbContext, TEntity, TKey>(Func<TKey, Expression<Func<TEntity, bool>>> predicateFactory)
+internal class UpdateEndpoint<TDbContext, TEntity, TKey>(
+    Func<TKey, Expression<Func<TEntity, bool>>> predicateFactory,
+    Expression<Func<TEntity, TKey>> idSelector)
     : GenericEndpointBase<TDbContext, TEntity>
     where TEntity : class
     where TDbContext : DbContext
 {
     protected readonly Func<TKey, Expression<Func<TEntity, bool>>> _predicateFactory = predicateFactory;
+
+    // Compiled once so the body id can be read and compared against the route id.
+    protected readonly Func<TEntity, TKey> _idAccessor = idSelector.Compile();
 
     protected async Task<Results<NoContent, NotFound, BadRequest<string>>> UpdateEntityAsync(
         TKey id, TDbContext context, ILogger logger, Action<TEntity> applyChanges, CancellationToken ct)
@@ -55,6 +60,14 @@ internal class UpdateEndpoint<TDbContext, TEntity, TKey>(Func<TKey, Expression<F
                     CancellationToken ct) =>
                 {
                     using var scope = LoggingScope.BeginEntityScope(logger, EntityName, id!);
+
+                    var bodyId = _idAccessor(updatedEntity);
+                    if (!EqualityComparer<TKey>.Default.Equals(bodyId, id))
+                    {
+                        return TypedResults.BadRequest(
+                            $"The id in the route ('{id}') does not match the id in the request body ('{bodyId}').");
+                    }
+
                     return await UpdateEntityAsync(id, context, logger,
                         e => context.Entry(e).CurrentValues.SetValues(updatedEntity), ct);
                 });
@@ -64,8 +77,12 @@ internal class UpdateEndpoint<TDbContext, TEntity, TKey>(Func<TKey, Expression<F
     }
 }
 
-internal class UpdateEndpoint<TDbContext, TEntity, TKey, TDto>(Func<TKey, Expression<Func<TEntity, bool>>> predicateFactory)
-    : UpdateEndpoint<TDbContext, TEntity, TKey>(predicateFactory)
+// The request DTO is decoupled from the entity key, so route/body id consistency
+// is not validated on this overload.
+internal class UpdateEndpoint<TDbContext, TEntity, TKey, TDto>(
+    Func<TKey, Expression<Func<TEntity, bool>>> predicateFactory,
+    Expression<Func<TEntity, TKey>> idSelector)
+    : UpdateEndpoint<TDbContext, TEntity, TKey>(predicateFactory, idSelector)
     where TEntity : class
     where TDbContext : DbContext
     where TDto : class

--- a/FastSharp.Tests/FastSharpEndpointsTests.cs
+++ b/FastSharp.Tests/FastSharpEndpointsTests.cs
@@ -154,6 +154,30 @@ public class FastSharpEndpointsTests
     }
 
     [Fact]
+    public async Task MapFastSharpEndpoints_Put_ReturnsBadRequestWhenBodyIdDiffersFromRoute()
+    {
+        await using var app = await CreateAppAsync();
+        var client = app.GetTestClient();
+
+        var createResponse = await client.PostAsJsonAsync("/api/sample", new TestModel { Id = 1, Name = "Original" });
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
+
+        var updateResponse = await client.PutAsJsonAsync("/api/sample/1", new TestModel { Id = 99, Name = "Hacked" });
+        Assert.Equal(HttpStatusCode.BadRequest, updateResponse.StatusCode);
+
+        // The stored entity must be left untouched after a rejected update.
+        var getResponse = await client.GetAsync("/api/sample/1");
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+        var model = await getResponse.Content.ReadFromJsonAsync<TestModel>();
+        Assert.NotNull(model);
+        Assert.Equal("Original", model!.Name);
+
+        // No row must have leaked under the body id.
+        var leakedResponse = await client.GetAsync("/api/sample/99");
+        Assert.Equal(HttpStatusCode.NotFound, leakedResponse.StatusCode);
+    }
+
+    [Fact]
     public async Task MapFastSharpEndpoints_Delete_ReturnsNotFoundWhenMissing()
     {
         await using var app = await CreateAppAsync();


### PR DESCRIPTION
The parameterless AddCRUD update overload bound the entity directly from the body without checking the route id, so a PUT to /resource/{id} with a different body id silently updated (or created) the wrong row. Compile the id selector once and compare the body id against the route id, returning BadRequest on mismatch. The DTO overload stays decoupled and is not affected.