### PR TITLE
fix(Modules): cap GetList results when no pagination params are provided

### DIFF
--- a/FastSharp.Modules/Configuration/CRUDEndpoints.cs
+++ b/FastSharp.Modules/Configuration/CRUDEndpoints.cs
@@ -14,6 +14,9 @@ public class CRUDEndpoints<TDbContext, TEntity, TKey> : ICrudEndpoints<TDbContex
 
     internal EndpointOptions ConfigAll = new();
 
+    // Per-endpoint GetList max page size override. Null means use the global FastSharpOptions value.
+    internal int? ListMaxPageSize;
+
     internal IGenericEndpoint GetByIdEndpoint;
     internal IGenericEndpoint GetListEndpoint;
     internal IGenericEndpoint CreateEndpoint;
@@ -113,6 +116,7 @@ public class CRUDEndpoints<TDbContext, TEntity, TKey> : ICrudEndpoints<TDbContex
         CRUDEndpoints<TDbContext, TEntity, TKey>.ConfigureEndpoint(GetByIdEndpoint, configure);
 
         GetListEndpoint = new GetListEndpoint<TDbContext, TEntity, TKey, TDto>(IdSelector);
+        ApplyListMaxPageSize();
         CRUDEndpoints<TDbContext, TEntity, TKey>.ConfigureEndpoint(GetListEndpoint, configure);
 
         CreateEndpoint = new CreateEndpoint<TDbContext, TEntity, TKey, TDto>(CrudPrefix);
@@ -130,6 +134,7 @@ public class CRUDEndpoints<TDbContext, TEntity, TKey> : ICrudEndpoints<TDbContex
         CRUDEndpoints<TDbContext, TEntity, TKey>.ConfigureEndpoint(GetByIdEndpoint, configure);
 
         GetListEndpoint = new GetListEndpoint<TDbContext, TEntity, TKey, TResponse>(IdSelector);
+        ApplyListMaxPageSize();
         CRUDEndpoints<TDbContext, TEntity, TKey>.ConfigureEndpoint(GetListEndpoint, configure);
 
         CreateEndpoint = new CreateEndpoint<TDbContext, TEntity, TKey, TRequest, TResponse>(CrudPrefix);
@@ -148,12 +153,36 @@ public class CRUDEndpoints<TDbContext, TEntity, TKey> : ICrudEndpoints<TDbContex
         CRUDEndpoints<TDbContext, TEntity, TKey>.ConfigureEndpoint(GetByIdEndpoint, configure);
     }
 
+    // Applies the stored per-endpoint max page size override to the current GetList endpoint
+    // (the DTO variant derives from the base, so a single cast covers both).
+    private void ApplyListMaxPageSize()
+    {
+        if (GetListEndpoint is GetListEndpoint<TDbContext, TEntity, TKey> listEndpoint)
+            listEndpoint.MaxPageSizeOverride = ListMaxPageSize;
+    }
+
     public void GetList(Action<RouteHandlerBuilder>? configure = null) =>
         CRUDEndpoints<TDbContext, TEntity, TKey>.ConfigureEndpoint(GetListEndpoint, configure);
+
+    public void GetList(int maxPageSize, Action<RouteHandlerBuilder>? configure = null)
+    {
+        ListMaxPageSize = maxPageSize;
+        ApplyListMaxPageSize();
+        CRUDEndpoints<TDbContext, TEntity, TKey>.ConfigureEndpoint(GetListEndpoint, configure);
+    }
 
     public void GetList<TDto>(Action<RouteHandlerBuilder>? configure = null) where TDto : class
     {
         GetListEndpoint = new GetListEndpoint<TDbContext, TEntity, TKey, TDto>(IdSelector);
+        ApplyListMaxPageSize();
+        CRUDEndpoints<TDbContext, TEntity, TKey>.ConfigureEndpoint(GetListEndpoint, configure);
+    }
+
+    public void GetList<TDto>(int maxPageSize, Action<RouteHandlerBuilder>? configure = null) where TDto : class
+    {
+        ListMaxPageSize = maxPageSize;
+        GetListEndpoint = new GetListEndpoint<TDbContext, TEntity, TKey, TDto>(IdSelector);
+        ApplyListMaxPageSize();
         CRUDEndpoints<TDbContext, TEntity, TKey>.ConfigureEndpoint(GetListEndpoint, configure);
     }
 

--- a/FastSharp.Modules/Configuration/FastSharpOptions.cs
+++ b/FastSharp.Modules/Configuration/FastSharpOptions.cs
@@ -1,0 +1,19 @@
+namespace FastSharp.Modules.Configuration;
+
+/// <summary>
+/// Global configuration for FastSharp generated endpoints.
+/// </summary>
+public class FastSharpOptions
+{
+    /// <summary>
+    /// The default maximum number of items a generated GetList endpoint may return.
+    /// </summary>
+    /// <remarks>
+    /// Applied as the upper bound when no pagination parameters are supplied (so an
+    /// unbounded <c>GET /items</c> returns at most this many rows) and when the
+    /// <c>pageSize</c> query parameter exceeds it. A per-endpoint override configured via
+    /// <see cref="ICrudEndpoints{TDbContext}.GetList(int, System.Action{Microsoft.AspNetCore.Builder.RouteHandlerBuilder}?)"/>
+    /// takes precedence over this value. Defaults to <c>100</c>.
+    /// </remarks>
+    public int MaxPageSize { get; set; } = 100;
+}

--- a/FastSharp.Modules/Configuration/ICrudEndpoints.cs
+++ b/FastSharp.Modules/Configuration/ICrudEndpoints.cs
@@ -65,12 +65,33 @@ public interface ICrudEndpoints<TDbContext> where TDbContext : DbContext
     public void GetList(Action<RouteHandlerBuilder>? configure = null);
 
     /// <summary>
+    /// Configures the GetList endpoint and overrides the maximum page size for this endpoint only.
+    /// </summary>
+    /// <remarks>
+    /// The override takes precedence over the global <see cref="FastSharpOptions.MaxPageSize"/>.
+    /// It caps the number of rows returned when no pagination parameters are supplied and acts as the
+    /// upper bound for the <c>pageSize</c> query parameter.
+    /// </remarks>
+    /// <param name="maxPageSize">The maximum page size for this endpoint. Values below 1 are treated as 1.</param>
+    /// <param name="configure">An optional delegate to further configure the route.</param>
+    public void GetList(int maxPageSize, Action<RouteHandlerBuilder>? configure = null);
+
+    /// <summary>
     /// By default returns <see cref="List{TEntity}"/>. When <c>page</c> and/or <c>pageSize</c>
     /// query parameters are provided, returns <see cref="PagedResult{TEntity}"/> instead.
     /// </summary>
     /// <param name="configure">An optional delegate to further configure the route using the provided RouteHandlerBuilder. If null, the route
     /// is added with default configuration.</param>
     public void GetList<TDto>(Action<RouteHandlerBuilder>? configure = null) where TDto : class;
+
+    /// <summary>
+    /// Configures the GetList endpoint with a DTO contract and overrides the maximum page size for
+    /// this endpoint only. The override takes precedence over the global <see cref="FastSharpOptions.MaxPageSize"/>.
+    /// </summary>
+    /// <typeparam name="TDto">The DTO type returned by the list endpoint.</typeparam>
+    /// <param name="maxPageSize">The maximum page size for this endpoint. Values below 1 are treated as 1.</param>
+    /// <param name="configure">An optional delegate to further configure the route.</param>
+    public void GetList<TDto>(int maxPageSize, Action<RouteHandlerBuilder>? configure = null) where TDto : class;
 
     public void Create(Action<RouteHandlerBuilder>? configure = null);
     public void Create<TDto>(Action<RouteHandlerBuilder>? configure = null) where TDto : class;

--- a/FastSharp.Modules/Core/Endpoints/GetListEndpoint.cs
+++ b/FastSharp.Modules/Core/Endpoints/GetListEndpoint.cs
@@ -4,6 +4,7 @@ using FastSharp.Modules.Logging;
 using Mapster;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using System.Linq.Expressions;
 
 namespace FastSharp.Modules.Core.Endpoints;
@@ -15,11 +16,23 @@ internal class GetListEndpoint<TDbContext, TEntity, TKey>(Expression<Func<TEntit
 {
     protected readonly Expression<Func<TEntity, TKey>> _idSelector = idSelector;
 
-    protected static (IResult? error, int page, int pageSize) ValidatePagination(int? page, int? pageSize)
+    /// <summary>
+    /// Per-endpoint override for the maximum page size. When <c>null</c>, the global
+    /// <see cref="FastSharpOptions.MaxPageSize"/> is used instead.
+    /// </summary>
+    internal int? MaxPageSizeOverride { get; set; }
+
+    /// <summary>
+    /// Resolves the effective maximum page size, preferring the per-endpoint override over the
+    /// global option. Never below 1 so a misconfigured value cannot disable the endpoint.
+    /// </summary>
+    protected int ResolveMaxPageSize(FastSharpOptions options)
+        => Math.Max(1, MaxPageSizeOverride ?? options.MaxPageSize);
+
+    protected static (IResult? error, int page, int pageSize) ValidatePagination(int? page, int? pageSize, int maxPageSize)
     {
         int p = page ?? 1;
-        int ps = pageSize ?? 10;
-        const int maxPageSize = 100;
+        int ps = pageSize ?? Math.Min(10, maxPageSize);
 
         if (p < 1)
             return (TypedResults.BadRequest("Page must be greater than or equal to 1."), 0, 0);
@@ -32,13 +45,13 @@ internal class GetListEndpoint<TDbContext, TEntity, TKey>(Expression<Func<TEntit
 
     protected async Task<IResult> FetchListAsync<TResult>(
         TDbContext context, ILogger logger,
-        int? page, int? pageSize,
+        int? page, int? pageSize, int maxPageSize,
         Func<IQueryable<TEntity>, IQueryable<TResult>> project,
         CancellationToken ct)
     {
         if (page.HasValue || pageSize.HasValue)
         {
-            var (error, p, ps) = ValidatePagination(page, pageSize);
+            var (error, p, ps) = ValidatePagination(page, pageSize, maxPageSize);
             if (error is not null) return error;
 
             FastSharpLogger.LogGetListPaged(logger, EntityName, p, ps);
@@ -50,8 +63,11 @@ internal class GetListEndpoint<TDbContext, TEntity, TKey>(Expression<Func<TEntit
             return TypedResults.Ok(new PagedResult<TResult>(list, totalItems, p, ps));
         }
 
+        // No pagination parameters: still bounded by the effective max page size to avoid
+        // loading the entire table into memory.
         FastSharpLogger.LogGetListAll(logger, EntityName);
-        var allItems = await project(context.Set<TEntity>().AsNoTracking()).ToListAsync(ct);
+        var allItems = await project(
+            context.Set<TEntity>().AsNoTracking().OrderBy(_idSelector).Take(maxPageSize)).ToListAsync(ct);
         return TypedResults.Ok(allItems);
     }
 
@@ -62,12 +78,14 @@ internal class GetListEndpoint<TDbContext, TEntity, TKey>(Expression<Func<TEntit
             var builder = app.MapGet("/", async Task<IResult> (
                 [FromServices] TDbContext context,
                 [FromServices] ILogger<FastSharpEngine> logger,
+                [FromServices] IOptions<FastSharpOptions> fastSharpOptions,
                 [FromQuery] int? page,
                 [FromQuery] int? pageSize,
                 CancellationToken ct) =>
             {
+                int maxPageSize = ResolveMaxPageSize(fastSharpOptions.Value);
                 using var scope = LoggingScope.BeginEntityScope(logger, EntityName);
-                return await FetchListAsync(context, logger, page, pageSize, q => q, ct);
+                return await FetchListAsync(context, logger, page, pageSize, maxPageSize, q => q, ct);
             });
 
             InvokeBuilders(builder, allOptions, _options);
@@ -89,12 +107,14 @@ internal class GetListEndpoint<TDbContext, TEntity, TKey, TDto>(Expression<Func<
             var builder = app.MapGet("/", async Task<IResult> (
                 [FromServices] TDbContext context,
                 [FromServices] ILogger<FastSharpEngine> logger,
+                [FromServices] IOptions<FastSharpOptions> fastSharpOptions,
                 [FromQuery] int? page,
                 [FromQuery] int? pageSize,
                 CancellationToken ct) =>
             {
+                int maxPageSize = ResolveMaxPageSize(fastSharpOptions.Value);
                 using var scope = LoggingScope.BeginEntityScope(logger, EntityName);
-                return await FetchListAsync<TDto>(context, logger, page, pageSize, q => q.ProjectToType<TDto>(), ct);
+                return await FetchListAsync<TDto>(context, logger, page, pageSize, maxPageSize, q => q.ProjectToType<TDto>(), ct);
             });
 
             InvokeBuilders(builder, allOptions, _options);

--- a/FastSharp.Modules/DependencyInjection.cs
+++ b/FastSharp.Modules/DependencyInjection.cs
@@ -1,3 +1,4 @@
+using FastSharp.Modules.Configuration;
 using FastSharp.Modules.Logging;
 using FastSharp.Modules.Registry;
 using FluentValidation;
@@ -8,8 +9,25 @@ namespace FastSharp.Modules;
 
 public static class DependencyInjection
 {
+    /// <summary>
+    /// Registers FastSharp modules, endpoints, and validators from the given assemblies,
+    /// applying global FastSharp configuration such as the default GetList page size limit.
+    /// </summary>
+    /// <param name="services">The service collection to add registrations to.</param>
+    /// <param name="configure">An action that configures the global <see cref="FastSharpOptions"/>.</param>
+    /// <param name="assemblies">The assemblies to scan. Defaults to the calling assembly when none are provided.</param>
+    public static IServiceCollection AddFastSharpEndpoints(this IServiceCollection services, Action<FastSharpOptions> configure, params Assembly[] assemblies)
+    {
+        services.Configure(configure);
+        return services.AddFastSharpEndpoints(assemblies);
+    }
+
     public static IServiceCollection AddFastSharpEndpoints(this IServiceCollection services, params Assembly[] assemblies)
     {
+        // Ensure IOptions<FastSharpOptions> always resolves (default values) even when the
+        // configuring overload above is not used.
+        services.AddOptions();
+
         if (assemblies.Length == 0)
         {
             // If no assemblies are provided, use the calling assembly.

--- a/FastSharp.Tests/FastSharpEndpointsTests.cs
+++ b/FastSharp.Tests/FastSharpEndpointsTests.cs
@@ -1,5 +1,6 @@
 using FastSharp.Models;
 using FastSharp.Modules;
+using FastSharp.Modules.Configuration;
 using FastSharp.Modules.Registry;
 using FastSharp.Tests.Context;
 using FastSharp.Tests.Dtos;
@@ -21,7 +22,7 @@ namespace FastSharp.Tests;
 
 public class FastSharpEndpointsTests
 {
-    private static async Task<WebApplication> CreateAppAsync()
+    private static async Task<WebApplication> CreateAppAsync(Action<FastSharpOptions>? configureOptions = null)
     {
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
@@ -29,7 +30,10 @@ public class FastSharpEndpointsTests
         builder.Services.AddSingleton(databaseRoot);
         builder.Services.AddDbContext<TestDbContext>(options =>
             options.UseInMemoryDatabase("FastSharpTests", databaseRoot));
-        builder.Services.AddFastSharpEndpoints(typeof(SampleModule).Assembly);
+        if (configureOptions is null)
+            builder.Services.AddFastSharpEndpoints(typeof(SampleModule).Assembly);
+        else
+            builder.Services.AddFastSharpEndpoints(configureOptions, typeof(SampleModule).Assembly);
         builder.Services.AddScoped<ValidationRequestValidator>();
 
         var app = builder.Build();
@@ -271,6 +275,82 @@ public class FastSharpEndpointsTests
         Assert.Equal(3, result.TotalItems);
         Assert.Equal(2, result.Items.Count());
         Assert.Equal(new[] { 1, 2 }, result.Items.Select(item => item.Id).ToArray());
+    }
+
+    [Fact]
+    public async Task GetList_NoParams_CapsAtDefaultMaxPageSize()
+    {
+        await using var app = await CreateAppAsync();
+        var client = app.GetTestClient();
+
+        using (var scope = app.Services.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+            context.Models.AddRange(Enumerable.Range(1, 150)
+                .Select(i => new TestModel { Id = i, Name = $"Item {i}" }));
+            await context.SaveChangesAsync();
+        }
+
+        var response = await client.GetAsync("/api/sample");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var list = await response.Content.ReadFromJsonAsync<List<TestModel>>();
+        Assert.NotNull(list);
+        Assert.Equal(100, list!.Count);
+    }
+
+    [Fact]
+    public async Task GetList_NoParams_RespectsGlobalMaxPageSizeOverride()
+    {
+        await using var app = await CreateAppAsync(options => options.MaxPageSize = 5);
+        var client = app.GetTestClient();
+
+        using (var scope = app.Services.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+            context.Models.AddRange(Enumerable.Range(1, 20)
+                .Select(i => new TestModel { Id = i, Name = $"Item {i}" }));
+            await context.SaveChangesAsync();
+        }
+
+        var response = await client.GetAsync("/api/sample");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var list = await response.Content.ReadFromJsonAsync<List<TestModel>>();
+        Assert.NotNull(list);
+        Assert.Equal(5, list!.Count);
+    }
+
+    [Fact]
+    public async Task GetList_NoParams_PerEndpointMaxPageSizeOverridesGlobalDefault()
+    {
+        await using var app = await CreateAppAsync();
+        var client = app.GetTestClient();
+
+        using (var scope = app.Services.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+            context.Models.AddRange(Enumerable.Range(1, 20)
+                .Select(i => new TestModel { Id = i, Name = $"Item {i}" }));
+            await context.SaveChangesAsync();
+        }
+
+        var response = await client.GetAsync("/api/max-page");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var list = await response.Content.ReadFromJsonAsync<List<TestModel>>();
+        Assert.NotNull(list);
+        Assert.Equal(3, list!.Count);
+    }
+
+    [Fact]
+    public async Task GetList_PageSizeAbovePerEndpointMax_ReturnsBadRequest()
+    {
+        await using var app = await CreateAppAsync();
+        var client = app.GetTestClient();
+
+        var response = await client.GetAsync("/api/max-page?page=1&pageSize=10");
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [Fact]

--- a/FastSharp.Tests/Modules/MaxPageSizeModule.cs
+++ b/FastSharp.Tests/Modules/MaxPageSizeModule.cs
@@ -1,0 +1,13 @@
+using FastSharp.Modules.Core;
+using FastSharp.Tests.Context;
+
+namespace FastSharp.Tests.Modules
+{
+    public sealed class MaxPageSizeModule : Module<TestDbContext>
+    {
+        public MaxPageSizeModule()
+        {
+            AddCRUD<TestModel, int>("/max-page", crud => crud.GetList(maxPageSize: 3));
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Run the project and open `/openapi/v1.json` — you'll see the generated CRUD en
 
 | Method | Route | Description |
 |--------|-------|-------------|
-| `GET` | `/api/products/alternative` | Full list (add `?page=1&pageSize=10` for paginated results) |
+| `GET` | `/api/products/alternative` | List, capped at the default max page size (add `?page=1&pageSize=10` for paginated results) |
 | `GET` | `/api/products/alternative/{id}` | Get by ID |
 | `POST` | `/api/products/alternative` | Create |
 | `PUT` | `/api/products/alternative/{id}` | Update |

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -163,6 +163,38 @@ Resulting contracts:
 
 ---
 
+# Pagination and page size limits
+
+The generated GetList endpoint is always bounded. When a request omits `page` and `pageSize`,
+FastSharp returns a plain list capped at a **maximum page size** (default `100`) instead of loading
+the whole table. The same limit is the upper bound for the `pageSize` query parameter — requests above
+it get a `400 Bad Request`.
+
+You can change the limit at two levels. The most specific wins:
+
+**1) Globally**, for every GetList endpoint in the registered assemblies:
+
+```csharp
+builder.Services.AddFastSharpEndpoints(options =>
+{
+    options.MaxPageSize = 250;
+}, typeof(ProductsModule).Assembly);
+```
+
+**2) Per endpoint**, overriding the global value for a single CRUD registration:
+
+```csharp
+AddCRUD<Product, int>("/products", crud =>
+{
+    crud.GetList(maxPageSize: 25);
+    // DTO variant: crud.GetList<ProductDto>(maxPageSize: 25);
+});
+```
+
+Precedence: **per-endpoint `GetList(maxPageSize: …)` > global `FastSharpOptions.MaxPageSize` > framework default (`100`)**.
+
+---
+
 # Custom endpoints
 
 [Back to README](../README.md)


### PR DESCRIPTION
## Summary

- `GetListEndpoint` without pagination params previously loaded the entire table. Now it applies `Take(maxPageSize)` via EF Core, preventing unbounded queries.
- Introduces `FastSharpOptions` with `MaxPageSize = 100` as the global default, configurable via `AddFastSharpEndpoints(options => ..., assembly)`.
- Adds a per-endpoint override `crud.GetList(maxPageSize: N)` (and its DTO variant) that takes precedence over the global value.

## Changes

| File | Change |
|------|--------|
| `FastSharp.Modules/Configuration/FastSharpOptions.cs` | New — global options class with `MaxPageSize` |
| `FastSharp.Modules/Core/Endpoints/GetListEndpoint.cs` | Core fix: bounded query + `IOptions<FastSharpOptions>` injection |
| `FastSharp.Modules/Configuration/CRUDEndpoints.cs` | Per-endpoint `GetList(maxPageSize)` overloads |
| `FastSharp.Modules/Configuration/ICrudEndpoints.cs` | Interface: new overloads + XML docs |
| `FastSharp.Modules/DependencyInjection.cs` | New `AddFastSharpEndpoints` overload with `Action<FastSharpOptions>` |
| `FastSharp.Tests/FastSharpEndpointsTests.cs` | 4 new integration tests |
| `FastSharp.Tests/Modules/MaxPageSizeModule.cs` | New — test module with `maxPageSize: 3` |
| `docs/customization.md` | New section: pagination and page size limits |
| `README.md` | Minor wording update |

## Test plan

- [x] `GetList_NoParams_CapsAtDefaultMaxPageSize` — 150 rows, no params → returns 100
- [x] `GetList_NoParams_RespectsGlobalMaxPageSizeOverride` — global override to 5, 20 rows → returns 5
- [x] `GetList_NoParams_PerEndpointMaxPageSizeOverridesGlobalDefault` — per-endpoint override to 3, 20 rows → returns 3
- [x] `GetList_PageSizeAbovePerEndpointMax_ReturnsBadRequest` — `pageSize=10` on `maxPageSize=3` endpoint → `400`
- [x] All 24 existing tests pass

Closes #25